### PR TITLE
Enhance password validation logic in keystore

### DIFF
--- a/src/keystore.ts
+++ b/src/keystore.ts
@@ -36,6 +36,7 @@ export async function generateKeystore(projectDir: string) {
     // File doesn't exist, proceed
   }
 
+  let initialPassword = ''
   const response = await prompts([
     {
       type: 'text',
@@ -48,13 +49,19 @@ export async function generateKeystore(projectDir: string) {
       type: 'password',
       name: 'password',
       message: 'Keystore password (min 6 chars)',
-      validate: value => value.length >= 6 ? true : 'Password must be at least 6 characters'
+      validate: value => {
+        if (value.length >= 6) {
+          initialPassword = value
+          return true
+        }
+        return 'Password must be at least 6 characters'
+      }
     },
     {
       type: 'password',
       name: 'passwordConfirm',
       message: 'Confirm password',
-      validate: (value, values) => value === values.password ? true : 'Passwords do not match'
+      validate: value => value === initialPassword ? true : 'Passwords do not match'
     },
     {
       type: 'text',


### PR DESCRIPTION
## Bug description

When `nitron keystore` asks for password confirmation, the validator for `passwordConfirm` expects `values.password` to exist.

But with the installed `prompts` version, the `validate` callback only receives the current value, not the full answers object. So `values.password` is `undefined`, causing the confirm check to fail even when both entries match.

### Result
- `Keystore password` accepts a valid password
- `Confirm password` rejects it with `Passwords do not match`
- The bug is in `src/keystore.ts` validation logic

### Fix
Store the first password in a local variable when the user enters it, then compare the confirmation against that stored value instead of `values.password`.